### PR TITLE
fix test errors and deprecations on julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+# matrix:
+#   allow_failures:
+#     - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.7-alpha
 NearestNeighbors
 RecipesBase

--- a/src/ConcaveHull.jl
+++ b/src/ConcaveHull.jl
@@ -2,6 +2,7 @@ module ConcaveHull
 
 using NearestNeighbors
 using RecipesBase
+using LinearAlgebra
 
 include("hull.jl")
 include("concave_hull.jl")

--- a/src/concave_hull.jl
+++ b/src/concave_hull.jl
@@ -2,7 +2,7 @@ function cross2d(x,y)
     return x[1]*y[2] - x[2]*y[1]
 end
 
-function intersect_line{T<:AbstractVector,S<:AbstractVector}(ls1::NTuple{2,T},ls2::NTuple{2,S})
+function intersect_line(ls1::NTuple{2,T},ls2::NTuple{2,S}) where {T<:AbstractVector,S<:AbstractVector}
     r = ls1[2] - ls1[1]
     s = ls2[2] - ls2[1]
     qmp = ls2[1]-ls1[1]
@@ -15,7 +15,7 @@ end
 function get_angle(p_pro,p_cur,p_pre)
     r = p_pro - p_cur
     p = p_pre - p_cur
-    t = atan2(cross2d(p,r),dot(p,r))
+    t = atan(cross2d(p,r),dot(p,r))
     return t > 0 ? t : t + 2pi
 end
 
@@ -33,13 +33,26 @@ function intersect_hull(ls, hull)
     return false
 end
 
+function indmax_f(f::Function, itr::AbstractVector)
+    imax = firstindex(itr)
+    vmax = f(first(itr))
+    for i in (imax+1):lastindex(itr)
+        v = f(itr[i])
+        if v > vmax
+            vmax = v
+            imax = i
+        end
+    end
+    imax
+end
+
 function concave_hull(tree::KDTree, k::Int)
     npoints = length(tree.data)
     k = clamp(k, 3, npoints-1)
     hull = Hull(eltype(tree.data), k)
 
     #Start at point with largest x value
-    i0 = indmax(v[1] for v in tree.data)
+    i0 = indmax_f(v -> v[1], tree.data)
 
     ishull = zeros(Bool,npoints)
     ishull[i0] = true

--- a/src/concave_hull.jl
+++ b/src/concave_hull.jl
@@ -33,10 +33,13 @@ function intersect_hull(ls, hull)
     return false
 end
 
+# In Julia v0.7 and above, indmax cannot be used with generators.
+# In a future version, we should be able to replace this function
+# with Base.argmax(f, itr)
 function indmax_f(f::Function, itr::AbstractVector)
     imax = firstindex(itr)
-    vmax = f(first(itr))
-    for i in (imax+1):lastindex(itr)
+    vmax = f(itr[imax])
+    for i in (firstindex(itr)+1):lastindex(itr)
         v = f(itr[i])
         if v > vmax
             vmax = v

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -3,7 +3,7 @@ struct Hull{T<:AbstractVector}
     k::Int
 end
 
-Hull{S<:AbstractVector}(T::Type{S},k::Int) = Hull(T[],k)
+Hull(::Type{T},k::Int) where {T<:AbstractVector} = Hull(T[],k)
 
 function is_left(p0,p1,p2)
     return ((p1[1] - p0[1]) * (p2[2] - p0[2]) - (p2[1] -  p0[1]) * (p1[2] - p0[2]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ConcaveHull
-using Base.Test
+using Test
 
 # Triangle
 p = [[-1.0,0.0],[1.0,0.0],[0.0,1.0]]


### PR DESCRIPTION
Happy [Upgradathon Friday](https://discourse.julialang.org/t/ann-introducing-upgradathon-fridays/12047)!

This PR fixes the test errors and deprecation warnings on Julia v0.7. It also updates the minimum required Julia version to v0.7-alpha. 