### PR TITLE
Bump compat for RecipesBase.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 NearestNeighbors = "^0.4.3"
-RecipesBase = "^0.7"
+RecipesBase = "^0.7, 1"
 julia = "^1"
 
 [extras]


### PR DESCRIPTION
Bump compat for RecipesBase.jl to include v1, otherwise massive downgrade of packages occur when installing ConcaveHull.jl.

Tests pass locally, and the examples in  https://github.com/lstagner/ConcaveHull.jl/blob/master/README.md work as well.