### PR TITLE
Suggestion: Add flag to check if the algorithm is successful

### DIFF
--- a/src/concave_hull.jl
+++ b/src/concave_hull.jl
@@ -123,14 +123,14 @@ function concave_hull(tree::KDTree, k::Int)
         return concave_hull(tree, k+1)
     end
 
-    return hull
+    return Hull(hull.vertices, hull.k, true)
 end
 
 function concave_hull(points::Vector, k::Int = 3)
     p = unique(points)
     npoints = length(p)
     npoints < 3 && throw(ArgumentError("Number of unique points should be greater than 2"))
-    npoints == 3 && return Hull(points,k)
+    npoints == 3 && return Hull(points,k, true)
     tree = KDTree(hcat(points...),reorder=false)
     return concave_hull(tree, k)
 end

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -1,9 +1,10 @@
 struct Hull{T<:AbstractVector}
     vertices::Vector{T}
     k::Int
+    converged::Bool
 end
 
-Hull(::Type{T},k::Int) where {T<:AbstractVector} = Hull(T[],k)
+Hull(::Type{T},k::Int) where {T<:AbstractVector} = Hull(T[],k, false)
 
 function is_left(p0,p1,p2)
     return ((p1[1] - p0[1]) * (p2[2] - p0[2]) - (p2[1] -  p0[1]) * (p1[2] - p0[2]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,13 @@ using Test
 p = [[-1.0,0.0],[1.0,0.0],[0.0,1.0]]
 h = concave_hull(p)
 @test Set(h.vertices) == Set(p)
+@test h.converged
 @test area(h) == 0.5*2
 
 # Triangle enclosing point
 p = [[-1.0,0.0],[1.0,0.0],[0.0,1.0],[0.0,0.5]]
 h = concave_hull(p)
+@test h.converged
 @test Set(p[1:3]) == Set(h.vertices)
 
 # Square
@@ -17,20 +19,29 @@ p = [[-1.0,0.0],[1.0,0.0],[1.0,2.0],[-1.0,2.0]]
 h = concave_hull(p)
 @test Set(h.vertices) == Set(p)
 @test area(h) == 4.0
+@test h.converged
 
 # Square with multiple points on one side
 p = [[-1.0,0.0], [1.0,0.0], [1.0,0.25], [1.0,0.5], [1.0,0.75],
      [1.0,1.0], [1.0,1.25], [1.0,1.5], [1.0,1.75], [1.0,2.0], [-1.0,2.0]]
 h = concave_hull(p)
 @test area(h) == 4.0
+@test h.converged
 
 # Square enclosing point
 p = [[-1.0,0.0],[1.0,0.0],[1.0,2.0],[-1.0,2.0],[0.0,1.0]]
 h = concave_hull(p)
 @test Set(p[1:4]) == Set(h.vertices)
+@test h.converged
 
 # Square enclosing many points
 p = [[-1.0,0.0],[1.0,0.0],[1.0,2.0],[-1.0,2.0]]
 pr = [[-0.99,0.01] + 1.98*rand(2) for i=1:100]
 h = concave_hull(vcat(p,pr))
 @test issubset(Set(p), Set(h.vertices))
+@test h.converged
+
+# Test non-convergence case
+p = [[-1.0, -1.0], [0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]
+h = concave_hull(p)
+@test h.converged == false


### PR DESCRIPTION
For my own project, I needed to make sure that the ConcaveHull had built correctly when passing it a list of points. Currently, if the algorithm fails to converge it prints an informative message, but I don't think there is anyway to actually check if it has converged.

The simplest way I thought this could be added is by adding an extra field to the Hull structure. I don't know if this is ideal, and I don't know if a function ``converged(hull::ConcaveHull.Hull)`` could be written that returned the flag rather than hard coding it.