### PR TITLE
Make `in_hull` not allocate and avoid copying vertices

### DIFF
--- a/src/hull.jl
+++ b/src/hull.jl
@@ -10,32 +10,28 @@ function is_left(p0,p1,p2)
     return ((p1[1] - p0[1]) * (p2[2] - p0[2]) - (p2[1] -  p0[1]) * (p1[2] - p0[2]))
 end
 
-function in_hull(p,hull::Hull)
-
-    v = copy(hull.vertices)
-    push!(v,hull.vertices[1])
-    nv = length(v)
+function in_hull(p, hull::Hull)
     wn = 0
-    @inbounds for i = 1:nv-1
-        if v[i][2] <= p[2]
-            if v[i+1][2] > p[2]
-                if is_left(v[i],v[i+1],p) > 0.0
-                    wn = wn +1
+    nv = length(hull.vertices)
+    @inbounds for i = 1:nv
+        current = hull.vertices[i]
+        next = hull.vertices[mod1(i + 1, nv)]
+        if current[2] <= p[2]
+            if next[2] > p[2]
+                if is_left(current, next, p) > 0.0
+                    wn += 1
                 end
             end
         else
-            if v[i+1][2] <= p[2]
-                if is_left(v[i],v[i+1],p) < 0.0
-                    wn = wn - 1
+            if next[2] <= p[2]
+                if is_left(current, next, p) < 0.0
+                    wn -= 1
                 end
             end
         end
     end
-    if wn == 0
-        return false
-    else
-        return true
-    end
+
+    return wn != 0
 end
 
 function signed_area(h::Hull)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ h = concave_hull(p)
 @test Set(h.vertices) == Set(p)
 @test h.converged
 @test area(h) == 0.5*2
+@test in_hull([0.0,0.5], h)
+@test !in_hull([3.0, 3.0], h)
 
 # Triangle enclosing point
 p = [[-1.0,0.0],[1.0,0.0],[0.0,1.0],[0.0,0.5]]


### PR DESCRIPTION
To achieve a "wrapping around" of vertices in `in_hull`, the vertices of the hull were previously copied and the first vertex pushed to the resulting vector. This is unnecessary work and can be done using Julia's `mod1` function as well.